### PR TITLE
improve extensibility for SpadeCli users

### DIFF
--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/ActivateCommand.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/ActivateCommand.scala
@@ -1,10 +1,10 @@
 package com.salesforce.mce.spade.cli
 
+import java.util.concurrent.Callable
+
 import com.salesforce.mce.spade.orchard.{OrchardClient, OrchardClientForPipeline}
 import com.salesforce.mce.telepathy.ErrorResponse
 import okhttp3.HttpUrl
-
-import java.util.concurrent.Callable
 
 class ActivateCommand(opt: CliOptions) extends Callable[Option[ErrorResponse]] {
 

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/ActivateCommand.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/ActivateCommand.scala
@@ -1,18 +1,19 @@
 package com.salesforce.mce.spade.cli
 
+import com.salesforce.mce.spade.orchard.{OrchardClient, OrchardClientForPipeline}
+import com.salesforce.mce.telepathy.ErrorResponse
 import okhttp3.HttpUrl
 
-import com.salesforce.mce.spade.orchard.{OrchardClient, OrchardClientForPipeline}
+import java.util.concurrent.Callable
 
-class ActivateCommand(opt: CliOptions) {
+class ActivateCommand(opt: CliOptions) extends Callable[Option[ErrorResponse]] {
 
-  def run(): Int = {
+  override def call(): Option[ErrorResponse] = {
     new OrchardClientForPipeline(
       OrchardClient.Setting(HttpUrl.parse(opt.host), opt.apiKey),
       opt.workflowId
     ).activate()
-
-    0
+    None
   }
 
 }

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/CancelCommand.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/CancelCommand.scala
@@ -2,21 +2,24 @@ package com.salesforce.mce.spade.cli
 
 import com.salesforce.mce.spade.orchard.OrchardClientForPipeline
 import com.salesforce.mce.spade.orchard.OrchardClient
+import com.salesforce.mce.telepathy.ErrorResponse
 import okhttp3.HttpUrl
 
-class CancelCommand(opt: CliOptions) {
+import java.util.concurrent.Callable
 
-  def run(): Int = {
+class CancelCommand(opt: CliOptions) extends Callable[Option[ErrorResponse]] {
+
+  override def call(): Option[ErrorResponse] = {
     new OrchardClientForPipeline(
       OrchardClient.Setting(HttpUrl.parse(opt.host), opt.apiKey),
       opt.workflowId
     ).cancel() match {
       case Right(i) =>
         println(i)
-        0
+        None
       case Left(e) =>
         println(e)
-        1
+        Some(e)
     }
   }
 

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/CancelCommand.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/CancelCommand.scala
@@ -1,11 +1,11 @@
 package com.salesforce.mce.spade.cli
 
-import com.salesforce.mce.spade.orchard.OrchardClientForPipeline
+import java.util.concurrent.Callable
+
 import com.salesforce.mce.spade.orchard.OrchardClient
+import com.salesforce.mce.spade.orchard.OrchardClientForPipeline
 import com.salesforce.mce.telepathy.ErrorResponse
 import okhttp3.HttpUrl
-
-import java.util.concurrent.Callable
 
 class CancelCommand(opt: CliOptions) extends Callable[Option[ErrorResponse]] {
 

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/CliOptions.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/CliOptions.scala
@@ -9,6 +9,9 @@ package com.salesforce.mce.spade.cli
 
 import com.salesforce.mce.spade.SpadeContext
 
+/*
+These are the argument options Cli commands look for, parsed automatically from SpadeCli args.
+ */
 case class CliOptions(
   command: Command,
   host: String,

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/Command.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/Command.scala
@@ -9,6 +9,9 @@ package com.salesforce.mce.spade.cli
 
 trait Command
 
+/*
+The are the core commands supported by SpadeCli.
+ */
 object Command {
 
   case object Generate extends Command

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/CreateCommand.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/CreateCommand.scala
@@ -1,12 +1,12 @@
 package com.salesforce.mce.spade.cli
 
+import java.util.concurrent.Callable
+
 import com.salesforce.mce.spade.SpadeWorkflowGroup
 import com.salesforce.mce.spade.orchard.OrchardClient
 import com.salesforce.mce.spade.orchard.OrchardClientForPipeline
 import com.salesforce.mce.telepathy.ErrorResponse
 import okhttp3.HttpUrl
-
-import java.util.concurrent.Callable
 
 class CreateCommand(opt: CliOptions, workflowGroup: SpadeWorkflowGroup) extends Callable[Option[ErrorResponse]] {
 

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/DeleteCommand.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/DeleteCommand.scala
@@ -1,22 +1,24 @@
 package com.salesforce.mce.spade.cli
 
-import com.salesforce.mce.spade.orchard.OrchardClientForPipeline
 import com.salesforce.mce.spade.orchard.OrchardClient
+import com.salesforce.mce.spade.orchard.OrchardClientForPipeline
+import com.salesforce.mce.telepathy.ErrorResponse
 import okhttp3.HttpUrl
 
-class DeleteCommand(opt: CliOptions) {
+import java.util.concurrent.Callable
 
-  def run(): Int = {
+class DeleteCommand(opt: CliOptions) extends Callable[Option[ErrorResponse]] {
+
+  override def call(): Option[ErrorResponse] = {
     new OrchardClientForPipeline(
       OrchardClient.Setting(HttpUrl.parse(opt.host), opt.apiKey),
       opt.workflowId
     ).delete() match {
       case Right(i) =>
         println(i)
-        0
+        None
       case Left(e) =>
-        println(e)
-        1
+        Some(e)
     }
   }
 

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/DeleteCommand.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/DeleteCommand.scala
@@ -1,11 +1,11 @@
 package com.salesforce.mce.spade.cli
 
+import java.util.concurrent.Callable
+
 import com.salesforce.mce.spade.orchard.OrchardClient
 import com.salesforce.mce.spade.orchard.OrchardClientForPipeline
 import com.salesforce.mce.telepathy.ErrorResponse
 import okhttp3.HttpUrl
-
-import java.util.concurrent.Callable
 
 class DeleteCommand(opt: CliOptions) extends Callable[Option[ErrorResponse]] {
 

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/GenerateCommand.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/GenerateCommand.scala
@@ -1,11 +1,11 @@
 package com.salesforce.mce.spade.cli
 
+import java.util.concurrent.Callable
+
 import com.salesforce.mce.spade.orchard.WorkflowRequest
 import com.salesforce.mce.spade.SpadeWorkflowGroup
 import com.salesforce.mce.telepathy.ErrorResponse
 import io.circe.syntax._
-
-import java.util.concurrent.Callable
 
 class GenerateCommand(opt: CliOptions, workflowGroup: SpadeWorkflowGroup) extends Callable[Option[ErrorResponse]] {
 

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/GenerateCommand.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/GenerateCommand.scala
@@ -1,13 +1,15 @@
 package com.salesforce.mce.spade.cli
 
-import io.circe.syntax._
-
 import com.salesforce.mce.spade.orchard.WorkflowRequest
 import com.salesforce.mce.spade.SpadeWorkflowGroup
+import com.salesforce.mce.telepathy.ErrorResponse
+import io.circe.syntax._
 
-class GenerateCommand(opt: CliOptions, workflowGroup: SpadeWorkflowGroup) {
+import java.util.concurrent.Callable
 
-  def run(): Int = {
+class GenerateCommand(opt: CliOptions, workflowGroup: SpadeWorkflowGroup) extends Callable[Option[ErrorResponse]] {
+
+  override def call(): Option[ErrorResponse] = {
     val requests = for {
       (workflowKey, workflow) <- workflowGroup.workflows
     } yield {
@@ -24,7 +26,8 @@ class GenerateCommand(opt: CliOptions, workflowGroup: SpadeWorkflowGroup) {
       case (false, false) =>
         requests.foreach(r => println(r.spaces2))
     }
-    0
+    None
   }
+
 
 }

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/GetCommand.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/GetCommand.scala
@@ -1,10 +1,10 @@
 package com.salesforce.mce.spade.cli
 
+import java.util.concurrent.Callable
+
 import com.salesforce.mce.spade.orchard.OrchardClient
 import com.salesforce.mce.telepathy.ErrorResponse
 import okhttp3.HttpUrl
-
-import java.util.concurrent.Callable
 
 class GetCommand(opt: CliOptions) extends Callable[Option[ErrorResponse]] {
 

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/GetCommand.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/GetCommand.scala
@@ -1,20 +1,21 @@
 package com.salesforce.mce.spade.cli
 
+import com.salesforce.mce.spade.orchard.OrchardClient
+import com.salesforce.mce.telepathy.ErrorResponse
 import okhttp3.HttpUrl
 
-import com.salesforce.mce.spade.orchard.OrchardClient
+import java.util.concurrent.Callable
 
-class GetCommand(opt: CliOptions) {
+class GetCommand(opt: CliOptions) extends Callable[Option[ErrorResponse]] {
 
-  def run(): Int = {
+  override def call(): Option[ErrorResponse] = {
     new OrchardClient(OrchardClient.Setting(HttpUrl.parse(opt.host), opt.apiKey))
       .forName(opt.pipelineName) match {
-        case Right(ps) =>
-          ps.foreach(println)
-          0
-        case Left(e) =>
-          println(e)
-          1
-      }
+      case Right(ps) =>
+        ps.foreach(println)
+        None
+      case Left(e) =>
+        Some(e)
+    }
   }
 }

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/SpadeCli.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/SpadeCli.scala
@@ -7,114 +7,149 @@
 
 package com.salesforce.mce.spade.cli
 
+import scopt.DefaultOParserSetup
 import scopt.OParser
-
-import com.salesforce.mce.spade.{BuildInfo, SpadeWorkflowGroup}
+import scopt.OParserSetup
+import com.salesforce.mce.spade.BuildInfo
+import com.salesforce.mce.spade.SpadeWorkflowGroup
 
 trait SpadeCli { self: SpadeWorkflowGroup =>
 
+  val builder = OParser.builder[CliOptions]
+
+  /*
+  This setup method allows implementations to this class to also use scopt for argument parsing.
+   */
+  val ignoreUnknownArguments: OParserSetup = new DefaultOParserSetup {
+    override def errorOnUnknownArgument: Boolean = false
+  }
+
+  /*
+  Each implementation's main method should call super.main(args) after initialization.
+   */
   def main(args: Array[String]): Unit = {
-    val builder = OParser.builder[CliOptions]
 
-    val parser = {
-      import builder._
-      OParser.sequence(
-        programName("spade-cli"),
-        head("spade-cli", BuildInfo.version),
-        help("help").text("prints this usage text"),
-        cmd("generate")
-          .action((_, c) => c.copy(command = Command.Generate))
-          .children(
-            opt[Unit]("compact")
-              .action((_, c) => c.copy(compact = true))
-              .text("If specified, the workflow json will be unindented."),
-            opt[Unit]("array")
-              .action((_, c) => c.copy(array = true))
-              .text("If specified, the workflow json will be wrapped in array.")
-          ),
-        cmd("get")
-          .action((_, c) => c.copy(command = Command.Get))
-          .children(
-            opt[String]("name").action((x, c) => c.copy(pipelineName = x)).required()
-          ),
-        cmd("create")
-          .action((_, c) => c.copy(command = Command.Create))
-          .children(
-            opt[String]('h', "host")
-              .action((x, c) => c.copy(host = x))
-              .text("Orchard host name"),
-            opt[String]("api-key")
-              .action((x, c) => c.copy(apiKey = Option(x)))
-              .text("Orchard API key to use"),
-            opt[Unit]("activate")
-              .action((_, c) => c.copy(activate = true))
-              .text("If specified, the newly created pipeline will be activated.")
-          ),
-        cmd("activate")
-          .action((_, c) => c.copy(command = Command.Activate))
-          .children(
-            opt[String]('h', "host")
-              .action((x, c) => c.copy(host = x))
-              .text("orchard host name"),
-            opt[String]("api-key")
-              .action((x, c) => c.copy(apiKey = Option(x)))
-              .text("Orchard API key to use"),
-            opt[String]("workflow-id")
-              .required()
-              .action((x, c) => c.copy(workflowId = x))
-              .text("Workflow ID")
-          ),
-        cmd("delete")
-          .action((_, c) => c.copy(command = Command.Delete))
-          .children(
-            opt[String]('h', "host")
-              .action((x, c) => c.copy(host = x))
-              .text("orchard host name"),
-            opt[String]("api-key")
-              .action((x, c) => c.copy(apiKey = Option(x)))
-              .text("Orchard API key to use"),
-            opt[String]("workflow-id")
-              .required()
-              .action((x, c) => c.copy(workflowId = x))
-              .text("Workflow ID")
-          ),
-        cmd("cancel")
-          .action((_, c) => c.copy(command = Command.Cancel))
-          .children(
-            opt[String]('h', "host")
-              .action((x, c) => c.copy(host = x))
-              .text("orchard host name"),
-            opt[String]("api-key")
-              .action((x, c) => c.copy(apiKey = Option(x)))
-              .text("Orchard API key to use"),
-            opt[String]("workflow-id")
-              .required()
-              .action((x, c) => c.copy(workflowId = x))
-              .text("Workflow ID")
-          )
-      )
+    // Parse the core spadecli arguments
+    val optionParseResult = parseOptions(args)
+
+    optionParseResult match {
+      // Assuming all necessary arguments were present, run the Cli command
+      case Some(cliOptions: CliOptions) =>
+        this.run(cliOptions)
+      // If there was an error parsing necesary arguments, the program help should be printed
+      case _ =>
+        System.err.println("Spade Command parsing error")
     }
+  }
 
-    OParser.parse(parser, args, CliOptions(Command.Generate)) match {
-      case Some(opts) =>
-        val exitStatus = opts.command match {
-          case Command.Generate =>
-           new GenerateCommand(opts, self).run()
-          case Command.Get =>
-            new GetCommand(opts).run()
-          case Command.Create =>
-            new CreateCommand(opts, self).run()
-          case Command.Activate =>
-            new ActivateCommand(opts).run()
-          case Command.Delete =>
-            new DeleteCommand(opts).run()
-          case Command.Cancel =>
-            new CancelCommand(opts).run()
+  def parseOptions(args : Array[String]): Option[CliOptions] = {
+    import builder._
+    val parser = OParser.sequence(
+      programName("spade-cli"),
+      head("spade-cli", BuildInfo.version),
+      help("help").text("prints this usage text"),
+      cmd("generate")
+        .action((_, c) => c.copy(command = Command.Generate))
+        .children(
+          opt[Unit]("compact")
+            .action((_, c) => c.copy(compact = true))
+            .text("If specified, the workflow json will be unindented."),
+          opt[Unit]("array")
+            .action((_, c) => c.copy(array = true))
+            .text("If specified, the workflow json will be wrapped in array.")
+        ),
+      cmd("get")
+        .action((_, c) => c.copy(command = Command.Get))
+        .children(
+          opt[String]("name").action((x, c) => c.copy(pipelineName = x)).required()
+        ),
+      cmd("create")
+        .action((_, c) => c.copy(command = Command.Create))
+        .children(
+          opt[String]('h', "host")
+            .action((x, c) => c.copy(host = x))
+            .text("Orchard host name"),
+          opt[String]("api-key")
+            .action((x, c) => c.copy(apiKey = Option(x)))
+            .text("Orchard API key to use"),
+          opt[Unit]("activate")
+            .action((_, c) => c.copy(activate = true))
+            .text("If specified, the newly created pipeline will be activated.")
+        ),
+      cmd("activate")
+        .action((_, c) => c.copy(command = Command.Activate))
+        .children(
+          opt[String]('h', "host")
+            .action((x, c) => c.copy(host = x))
+            .text("orchard host name"),
+          opt[String]("api-key")
+            .action((x, c) => c.copy(apiKey = Option(x)))
+            .text("Orchard API key to use"),
+          opt[String]("workflow-id")
+            .required()
+            .action((x, c) => c.copy(workflowId = x))
+            .text("Workflow ID")
+        ),
+      cmd("delete")
+        .action((_, c) => c.copy(command = Command.Delete))
+        .children(
+          opt[String]('h', "host")
+            .action((x, c) => c.copy(host = x))
+            .text("orchard host name"),
+          opt[String]("api-key")
+            .action((x, c) => c.copy(apiKey = Option(x)))
+            .text("Orchard API key to use"),
+          opt[String]("workflow-id")
+            .required()
+            .action((x, c) => c.copy(workflowId = x))
+            .text("Workflow ID")
+        ),
+      cmd("cancel")
+        .action((_, c) => c.copy(command = Command.Cancel))
+        .children(
+          opt[String]('h', "host")
+            .action((x, c) => c.copy(host = x))
+            .text("orchard host name"),
+          opt[String]("api-key")
+            .action((x, c) => c.copy(apiKey = Option(x)))
+            .text("Orchard API key to use"),
+          opt[String]("workflow-id")
+            .required()
+            .action((x, c) => c.copy(workflowId = x))
+            .text("Workflow ID")
+        )
+      )
+
+      val parseResult = OParser.parse(parser, args, CliOptions(Command.Generate), ignoreUnknownArguments)
+
+      parseResult
+  }
+
+  def run(opts: CliOptions) = {
+
+    val commandResponse = opts.command match {
+      case Command.Generate =>
+        new GenerateCommand(opts, self).call()
+      case Command.Get =>
+        new GetCommand(opts).call()
+      case Command.Create =>
+        new CreateCommand(opts, self).call()
+      case Command.Activate =>
+        new ActivateCommand(opts).call()
+      case Command.Delete =>
+        new DeleteCommand(opts).call()
+      case Command.Cancel =>
+        new CancelCommand(opts).call()
+    }
+    if (commandResponse.isDefined) {
+      commandResponse.get.message match {
+        case Left(exception) => {
+          exception.printStackTrace()
         }
-        System.exit(exitStatus)
-      case None =>
-        println("error")
-        System.exit(1)
+        case Right(message) => {
+          System.err.println(message)
+        }
+      }
     }
 
   }

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/SpadeCli.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/SpadeCli.scala
@@ -12,6 +12,7 @@ import scopt.OParser
 import scopt.OParserSetup
 import com.salesforce.mce.spade.BuildInfo
 import com.salesforce.mce.spade.SpadeWorkflowGroup
+import com.salesforce.mce.telepathy.ErrorResponse
 
 trait SpadeCli { self: SpadeWorkflowGroup =>
 
@@ -141,15 +142,15 @@ trait SpadeCli { self: SpadeWorkflowGroup =>
       case Command.Cancel =>
         new CancelCommand(opts).call()
     }
-    if (commandResponse.isDefined) {
-      commandResponse.get.message match {
+    commandResponse match {
+      case Some(x: ErrorResponse) => x.message match {
         case Left(exception) => {
-          exception.printStackTrace()
+          exception.printStackTrace(System.err)
         }
         case Right(message) => {
           System.err.println(message)
         }
-      }
+      } case None =>
     }
 
   }

--- a/spade-core/src/main/scala/com/salesforce/mce/spade/cli/SpadeCli.scala
+++ b/spade-core/src/main/scala/com/salesforce/mce/spade/cli/SpadeCli.scala
@@ -7,12 +7,12 @@
 
 package com.salesforce.mce.spade.cli
 
-import scopt.DefaultOParserSetup
-import scopt.OParser
-import scopt.OParserSetup
 import com.salesforce.mce.spade.BuildInfo
 import com.salesforce.mce.spade.SpadeWorkflowGroup
 import com.salesforce.mce.telepathy.ErrorResponse
+import scopt.DefaultOParserSetup
+import scopt.OParser
+import scopt.OParserSetup
 
 trait SpadeCli { self: SpadeWorkflowGroup =>
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
- ThisBuild / version := "0.13.1"
+ThisBuild / version := "0.14.0"


### PR DESCRIPTION
- seperate the business login out of main() into run()
  * makes it easier for implementations or tests to use capabilities without calling main
- prevent process exit if an unrecognized argument is detected
  * make it possible for implementations to use scopt too
- commands return error codes and details,  not process status
  * allow tests to assert using details of expected failure modes

should be backward compatible, thus minor version bump